### PR TITLE
add downloaded image to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+wss-wu-dryville.jpg


### PR DESCRIPTION
Update repo with a Dryville image. Ignoring the image file for git tracking. Addresses issue #16 